### PR TITLE
Preventing non-existent attribute names from throwing JS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ song.get('album.release.year'); // "1987"
 
 // Regular attributes
 song.get('title') // "Lucy In The Sky With Diamonds"
+
+// Non-existent attributes will not throw JS errors
+song.get('composer.name'); // undefined
 ```
 
 ## Supported Methods ##

--- a/backbone-dotattr.js
+++ b/backbone-dotattr.js
@@ -1,12 +1,16 @@
-(function(_, Backbone) {
+(function(_, Backbone, undefined) {
     _.extend(Backbone.Model.prototype, {
         get: function(key) {
-            return _.reduce(key.split('.'), function(attr, key) {
-                if (attr instanceof Backbone.Model)
-                    return attr.attributes[key];
+            try {
+                return _.reduce(key.split('.'), function(attr, key) {
+                    if (attr instanceof Backbone.Model)
+                        return attr.attributes[key];
 
-                return attr[key];
-            }, this.attributes);
+                    return attr[key];
+                }, this.attributes);
+            } catch (e) {
+                return undefined;
+            }
         }
     });
 })(window._, window.Backbone);

--- a/test/tests.js
+++ b/test/tests.js
@@ -23,3 +23,15 @@ test("has model attribute", function() {
     ok(song.has('album.title'));
     ok(song.has('album.release.year'));
 });
+
+test("has non-existent attributes", function() {
+    strictEqual(song.has('notpresent'), false);
+    strictEqual(song.has('notpresent.title'), false);
+    strictEqual(song.has('notpresent.release.year'), false);
+});
+
+test("get non-existent model attribute", function() {
+    strictEqual(song.get('notpresent'), undefined);
+    strictEqual(song.get('notpresent.title'), undefined);
+    strictEqual(song.get('notpresent.release.year'), undefined);
+});


### PR DESCRIPTION
Backbone returns `undefined` when you `get` an attribute that's not
present in the model, and `false` on calling `has`. The same behaviour
should apply dot-attributes, too.

Tests are updated as well.
