### PR TITLE
Added support for the string properties with a dot symbol

### DIFF
--- a/backbone-dotattr.js
+++ b/backbone-dotattr.js
@@ -1,10 +1,11 @@
 (function(_, Backbone) {
     _.extend(Backbone.Model.prototype, {
         get: function(key) {
-            return _.reduce(key.split('.'), function(attr, key) {
+            return typeof this.attributes[key] != 'undefined'
+                ? this.attributes[key]
+                : _.reduce(key.split('.'), function (attr, key) {
                 if (attr instanceof Backbone.Model)
                     return attr.attributes[key];
-
                 return attr[key];
             }, this.attributes);
         }


### PR DESCRIPTION
Allows users to get string properties with dot symbol as well as deep nested properties.
With this update if there is a string property with dot notation (for example "car.color"), we will try to get this property by a full string name. If it is impossible we will process in the usual dotattr way.

Example:
model: {
    "car.color" : "red"
}
model: {
    car: {
        color : "red"
    }
}

model.get("car.color") - will work with any of the above model.
